### PR TITLE
✨ update  , tower강화 기능

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -203,7 +203,7 @@ function openTowerShop() {
   getShop.style.display = 'block';
 }
 
-// 타워 구매 함수
+// 타워 구매 함수 #30
 function towerBuy(shopNumber) {
   const { x, y } = getRandomPositionNearPath(200);
 
@@ -234,6 +234,12 @@ export function towerBuyAgree(towerType, position) {
 // 타워 판매 함수
 export function towerSellAgree(target) {
   towers = towers.filter((t) => t.x !== target.x && t.y !== target.y);
+}
+
+// 타워 강화 함수
+export function towerEnhanceAgree(position, data) {
+  const findTower = towers.find((i) => i.x === position.x && i.y === position.y);
+  findTower.enhance(data);
 }
 
 function placeBase() {
@@ -393,7 +399,7 @@ export function setTowers(towerList) {
     towerImage.push(img);
     // 상점 UI 갱신
     document.getElementById(`productName${i + 1}`).innerHTML =
-      `${towerData[i].name.replace(/"/g, ' - ')}<br> 가격 : ${towerData[i].price}G`;
+      `== ${towerData[i].name} ==<br> 가격 : ${towerData[i].price}G`;
 
     // 타워 구매 버튼
     const div = document.getElementById(`productName${i + 1}`);
@@ -459,6 +465,7 @@ cCanvas.addEventListener('click', (event, tower) => {
   }
 });
 
+// 타워 클릭 시 메뉴
 function towerMenu(tower) {
   buttonContainer.innerHTML = '';
 
@@ -480,11 +487,19 @@ function towerMenu(tower) {
   enhanceButton.style.width = '80px';
   enhanceButton.style.height = '30px';
 
-  // 판매 버튼 기능
+  // 판매 버튼 기능 #31
   sellButton.addEventListener('click', () => {
     const x = tower.x;
     const y = tower.y;
     sendEvent(31, { towerType: tower.type, position: { x, y } });
+    buttonContainer.innerHTML = '';
+  });
+
+  // 강화 버튼 기능 #32
+  enhanceButton.addEventListener('click', () => {
+    const x = tower.x;
+    const y = tower.y;
+    sendEvent(32, { towerType: tower.type, position: { x, y } });
     buttonContainer.innerHTML = '';
   });
 

--- a/public/socket.js
+++ b/public/socket.js
@@ -9,6 +9,7 @@ import {
   moveStage,
   diplayEvent,
   towerSellAgree,
+  towerEnhanceAgree,
 } from './game.js';
 
 const IP = 'http://localhost:3005';
@@ -27,6 +28,7 @@ let monsters = null;
 let roundMonsters = null;
 let score = null;
 let userGold = null;
+let enhance = null;
 
 let targetStage = 0;
 
@@ -127,21 +129,32 @@ const socketConnection = () => {
           setMonstersGold(data.totalGold);
           break;
 
-        case 30:
-          if (data.error) {
-            diplayEvent(data.message, 'red', 65, 70);
+        case 30: // 타워 구매
+          if (data.status === 'fail' && data.error) {
+            diplayEvent(data.message, 'crimson', 65, 70);
           } else {
+            diplayEvent(data.message, 'black', 25, 35);
             towerBuyAgree(data.towerType - 1, data.position);
             setMonstersGold(data.totalGold);
           }
-
           break;
 
-        case 31:
-          if (data.error) {
+        case 31: // 타워 판매
+          if (data.status === 'fail' && data.error) {
             diplayEvent(data.message, 'red', 65, 70);
           } else {
+            diplayEvent(data.message, 'black', 30, 35);
             towerSellAgree(data.position);
+            setMonstersGold(data.totalGold);
+          }
+          break;
+
+        case 32: // 타워 강화
+          if (data.status === 'fail' && data.error) {
+            diplayEvent(data.message, 'crimson', 55, 40);
+          } else {
+            diplayEvent(data.message, 'blue', 35, 40);
+            towerEnhanceAgree(data.position, data.enhanceData);
             setMonstersGold(data.totalGold);
           }
           break;

--- a/public/tower.js
+++ b/public/tower.js
@@ -14,6 +14,7 @@ export class Tower {
     this.cooldown = 0;
     this.image = image;
     this.type = type;
+    this.enhanceLevel = 0;
   }
 
   draw(ctx) {
@@ -28,6 +29,16 @@ export class Tower {
       ctx.closePath();
       this.beamDuration--;
     }
+
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
+    ctx.fillRect(this.x - 22, this.y + 155, 120, 27);
+
+    ctx.fillStyle = 'yellow';
+    ctx.fillText(
+      `${'★'.repeat(this.enhanceLevel)}` + `${'☆'.repeat(5 - this.enhanceLevel)}`,
+      this.x + 37,
+      this.y + 175,
+    );
   }
 
   attack(monster) {
@@ -44,5 +55,13 @@ export class Tower {
     if (this.cooldown > 0) {
       this.cooldown--;
     }
+  }
+
+  enhance(data) {
+    this.attackPower += data.increasePower;
+    this.attackRange += data.increaseRange;
+    this.attackSpeed -= data.increaseSpeed;
+    this.enhanceLevel = data.enhanceLevel;
+    // this.image = 강화 이미지 계획은 폐기
   }
 }

--- a/src/handlers/handlerMapping.js
+++ b/src/handlers/handlerMapping.js
@@ -1,5 +1,5 @@
 import { gameEnd, gameStart } from './game.handler.js';
-import { towerBuy, towerSell } from './tower.handler.js';
+import { towerBuy, towerSell, towerEnhance } from './tower.handler.js';
 import { monsterKill } from './monsterKill.handler.js';
 import { moveStage } from './stage.handler.js';
 
@@ -10,6 +10,7 @@ const handlerMappings = {
   21: monsterKill,
   30: towerBuy,
   31: towerSell,
+  32: towerEnhance,
 };
 
 export default handlerMappings;

--- a/src/handlers/tower.handler.js
+++ b/src/handlers/tower.handler.js
@@ -1,11 +1,24 @@
-import { setTower, getTower, updateTower } from '../models/tower.model.js';
+import { setTower, getTower, updateTower, enhanceTower } from '../models/tower.model.js';
 import { clearGold, getGold, setGold, getTotalGold } from '../models/gold.model.js';
 import { getTowerDatas } from '../models/mTower.model.js';
+import { getEnhanceDatas } from '../models/mEnhance.model.js';
 
-// 타워 구매 핸들러
+// #30 타워 구매 핸들러
 export const towerBuy = async (userId, payload) => {
-  const towerMetadata = await getTowerDatas();
-  const findTowerId = towerMetadata.find((id) => id.towerId === payload.towerType);
+  //★★ 타워 갯수 제한
+  const towerLimit = 12;
+  const beforeTowers = await getTower(userId);
+
+  if (beforeTowers.length >= towerLimit) {
+    return {
+      status: 'fail',
+      message: ` 더 이상 타워를 구매할 수 없습니다.  <${towerLimit} 개 제한> `,
+      error: true,
+    };
+  }
+
+  const towerMetaData = await getTowerDatas();
+  const findTowerId = towerMetaData.find((id) => id.towerId === payload.towerType);
   const beforeTotalGold = await getTotalGold(userId);
 
   if (beforeTotalGold < findTowerId.price) {
@@ -17,7 +30,7 @@ export const towerBuy = async (userId, payload) => {
 
   const totalGold = await getTotalGold(userId);
 
-  await setTower(userId, payload.towerType, payload.position);
+  await setTower(userId, payload.towerType, payload.position, 0);
   console.log('현재 타워 목록', await getTower(userId));
 
   return {
@@ -30,21 +43,28 @@ export const towerBuy = async (userId, payload) => {
   //
 };
 
-// 타워 판매 핸들러
+// #31 타워 판매 핸들러
 export const towerSell = async (userId, payload) => {
-  const towerMetadata = await getTowerDatas();
-  const findTowerId = towerMetadata.find((id) => id.towerId === payload.towerType);
-
-  //판매금액
-  const sellPrice = findTowerId.price / 2;
+  const towerMetaData = await getTowerDatas();
+  const findTowerId = towerMetaData.find((id) => id.towerId === payload.towerType);
+  const enhanceMetaData = await getEnhanceDatas();
 
   const beforeTowers = await getTower(userId);
 
   //판매 대상
-  const targetTower = beforeTowers.find((i) => i.x === payload.x && i.y === payload.y);
+  const targetTower = beforeTowers.find(
+    (i) => i.position.x === payload.position.x && i.position.y === payload.position.y,
+  );
 
   if (!targetTower) {
     return { status: 'fail', message: ' 잘못된 대상입니다. ', error: true };
+  }
+
+  // 강화 비용에 대한 서비스
+  const targetMetaData = enhanceMetaData.filter((i) => i.towerId === findTowerId.towerId);
+  let enahncePrice = 0;
+  for (let i = targetTower.enhanceLevel - 1; i >= 0; i--) {
+    enahncePrice += targetMetaData[i].price;
   }
 
   //팔고 남은 타워
@@ -56,16 +76,69 @@ export const towerSell = async (userId, payload) => {
   console.log('타워 판매 후 보유한 타워들', afterTowers);
   const towerCount = afterTowers.length;
 
-  // 소지금 + findTowerId.price 해서 쌓아두기
+  // 정산 하기 (타워구매+강화에 들어간 골드의 절반)
+  const sellPrice = (findTowerId.price + enahncePrice) / 2;
   setGold(userId, +sellPrice);
   const totalGold = await getTotalGold(userId);
   console.log('타워 판매 후 잔액 => ', totalGold);
 
   return {
     status: 'success',
-    message: `${findTowerId.name} 타워를 판매했습니다. `,
+    message: `${findTowerId.name} 타워를 판매했습니다.  +${sellPrice} 골드 획득 ! `,
     position: payload.position,
     remaining: towerCount,
+    totalGold,
+  };
+};
+
+// #32 타워 강화 핸들러
+export const towerEnhance = async (userId, payload) => {
+  const towerMetadata = await getTowerDatas();
+  const beforeTowers = await getTower(userId);
+  const findTower = towerMetadata.find((id) => id.towerId === payload.towerType);
+  const enhanceMetaData = await getEnhanceDatas();
+
+  const findTarget = beforeTowers.find(
+    (i) => i.position.x === payload.position.x && i.position.y === payload.position.y,
+  );
+
+  const targetTowerIndex = beforeTowers.findIndex(
+    (i) => i.position.x === payload.position.x && i.position.y === payload.position.y,
+  );
+
+  if (targetTowerIndex === -1 || !findTarget) {
+    return { status: 'fail', message: ' 대상을 찾을 수 없습니다. ', error: true };
+  }
+
+  // 강화 대상 단계 데이터
+  const enhanceTargetInfo = enhanceMetaData.find(
+    (i) => i.towerId === findTower.towerId && i.enhanceLevel === findTarget.enhanceLevel + 1,
+  );
+
+  if (!enhanceTargetInfo) {
+    return { status: 'fail', message: ' 더 이상 강화 할 수 없습니다. ', error: true };
+  }
+
+  // 비용 정산
+  const currentGold = await getTotalGold(userId);
+  console.log('강화 비용', enhanceTargetInfo.price);
+
+  if (currentGold < enhanceTargetInfo.price) {
+    return { status: 'fail', message: ' 골드가 부족합니다. ', error: true };
+  }
+
+  setGold(userId, -enhanceTargetInfo.price);
+
+  const totalGold = await getTotalGold(userId);
+
+  await enhanceTower(userId, targetTowerIndex);
+
+  console.log('강화 후 타워 보유 목록', await getTower(userId));
+  return {
+    status: 'success',
+    message: ` ${findTower.name} 타워를 강화했습니다. ${findTarget.enhanceLevel} 강화 => ${enhanceTargetInfo.enhanceLevel} 강화`,
+    position: payload.position,
+    enhanceData: enhanceTargetInfo,
     totalGold,
   };
 };

--- a/src/init/initData.js
+++ b/src/init/initData.js
@@ -2,17 +2,20 @@ import { setTowerDatas, getTowerDatas, clearTowerDatas } from '../models/mTower.
 import { setMonsterDatas, getMonsterDatas, clearMonsterDatas } from '../models/mMonster.model.js';
 import { setStageDatas, getStageDatas, clearStageDatas } from '../models/mStages.model.js';
 import { getDataVersion, setDataVersion, clearDataVersion } from '../models/mVersion.model.js';
-import { TowersRepository } from '../repositories/towers.repository.js';
+import { setEnhanceDatas, getEnhanceDatas, clearEnhanceDatas } from '../models/mEnhance.model.js';
 
 import { PrismaClient } from '../../generated/clientGameDB/index.js';
 import { MonstersRepository } from '../repositories/monsters.repository.js';
 import { StagesRepository } from '../repositories/stages.repository.js';
+import { TowersRepository } from '../repositories/towers.repository.js';
+import { EnhanceRepository } from '../repositories/enhance.repository.js';
 
 const prisma = new PrismaClient();
 
 const towersRepository = new TowersRepository();
 const monstersRepository = new MonstersRepository();
 const stagesRepository = new StagesRepository();
+const enhanceRepository = new EnhanceRepository();
 
 /**
  * 서버 최초 기동 시,
@@ -24,6 +27,7 @@ export async function initData() {
    * Monsters
    * Stage
    * CreateMonsterPerStage
+   * TowerEnhance
    */
 
   const DATA_VERSION = '1.0.0';
@@ -34,8 +38,16 @@ export async function initData() {
   let towerRes = await getTowerDatas();
   let monsterRes = await getMonsterDatas();
   let stagesRes = await getStageDatas();
+  let enhanceRes = await getEnhanceDatas();
 
-  if (isVersion && isVersion === DATA_VERSION && towerRes && monsterRes && stagesRes) {
+  if (
+    isVersion &&
+    isVersion === DATA_VERSION &&
+    towerRes.length &&
+    monsterRes.length &&
+    stagesRes.length &&
+    enhanceRes.length
+  ) {
     console.log('@@@ 같은 버전의 게임 데이터가 레디스에 존재합니다.');
   } else {
     // clear
@@ -44,6 +56,7 @@ export async function initData() {
       clearStageDatas(),
       clearMonsterDatas(),
       clearDataVersion(),
+      clearEnhanceDatas(),
     ]).then(async () => {
       //--
       // TOWER
@@ -59,6 +72,10 @@ export async function initData() {
       await setStageDatas(stages);
 
       await setDataVersion(DATA_VERSION);
+
+      // TOWER_ENHANCE
+      const towerEnhance = await enhanceRepository.viewEntireEnhance();
+      await setEnhanceDatas(towerEnhance);
     });
   }
 }

--- a/src/models/mEnhance.model.js
+++ b/src/models/mEnhance.model.js
@@ -1,0 +1,31 @@
+import redisClient from '../init/redis.js';
+
+const KEY_PREFIX = 'enhancedatas:';
+const TTL = 60 * 60 * 24 * 7; // 7일
+
+/**
+ * 타워강화 메타 데이터 저장
+ * @param {*} data Towers 테이블 형식
+ */
+export const setEnhanceDatas = async (arr) => {
+  for (let i = 0; i < arr.length; i++) {
+    await redisClient.rPush(KEY_PREFIX, JSON.stringify(arr[i]), { EX: TTL });
+  }
+};
+
+/**
+ * 타워강화 메타 데이터 조회
+ * @returns {array} 데이터 전체 조회
+ */
+export const getEnhanceDatas = async () => {
+  let res = await redisClient.lRange(KEY_PREFIX, 0, -1);
+  res = res.map((e) => JSON.parse(e));
+  return res;
+};
+
+/**
+ * 타워강화 메타 데이터 삭제
+ */
+export const clearEnhanceDatas = () => {
+  redisClient.del(KEY_PREFIX);
+};

--- a/src/models/tower.model.js
+++ b/src/models/tower.model.js
@@ -7,8 +7,11 @@ const TTL = 60 * 60 * 24 * 7; // 7일
  * 타워 보유 추가
  * @param {*} data Towers 테이블 형식
  */
-export const setTower = async (userId, towerType, position) => {
-  await redisClient.rPush(KEY_PREFIX + userId, JSON.stringify({ towerType, position })),
+export const setTower = async (userId, towerType, position, enhanceLevel) => {
+  await redisClient.rPush(
+    KEY_PREFIX + userId,
+    JSON.stringify({ towerType, position, enhanceLevel }),
+  ),
     { EX: TTL };
 };
 
@@ -37,4 +40,17 @@ export const updateTower = async (userId, towers) => {
   for (let i = 0; i < towers.length; i++) {
     await redisClient.rPush(KEY_PREFIX + userId, JSON.stringify(towers[i]), { EX: TTL });
   }
+};
+
+/**
+ * 타워 강화 수치 갱신
+ */
+export const enhanceTower = async (userId, targetIndex) => {
+  let res = await redisClient.lRange(KEY_PREFIX + userId, 0, -1);
+
+  // targetIndex의 enhanceLevel +1
+  const tower = JSON.parse(res[targetIndex]);
+  tower.enhanceLevel++;
+  const enhancedTower = JSON.stringify(tower);
+  await redisClient.lSet(KEY_PREFIX + userId, targetIndex, enhancedTower);
 };

--- a/src/repositories/enhance.repository.js
+++ b/src/repositories/enhance.repository.js
@@ -1,0 +1,17 @@
+import { PrismaClient } from '../../generated/clientGameDB/index.js';
+
+const prisma = new PrismaClient();
+export class EnhanceRepository {
+  /**
+   *
+   * @returns 타워 강화정보 Colum
+   *    */
+  viewEntireEnhance = async () => {
+    return await prisma.TowerEnhance.findMany();
+  };
+}
+
+export const findEnhance = async () => {
+  const findEnhance = await prisma.TowerEnhance.findMany();
+  return findEnhance;
+};


### PR DESCRIPTION
타워 강화 초안입니다 

추가로 타워(구매) 제한 갯수가 12개로 제한되었습니다

타워 판매 시  
(타워 구매가격 + 타워 강화에 들어간 골드) /2 의 골드를 돌려 받습니다 

타워 강화에 필요한 모든 데이터는 
enhance  메타 데이터를 참조합니다

클라이언트는 강화 테이블을 따로 전달 받지 않습니다

++ 강화 한 티가 나도록 살짝 건드림